### PR TITLE
update plugin.method("init")

### DIFF
--- a/simpleFundsOverview/funds.py
+++ b/simpleFundsOverview/funds.py
@@ -92,7 +92,7 @@ def funds(unit=None, plugin=None):
     }
 
 
-@plugin.method("init")
+@plugin.init()
 def init(options, configuration, plugin):
     global rpc_interface
     plugin.log("start initialization of the funds plugin", level="debug")


### PR DESCRIPTION
@plugin.method("init") causes a value error "name already bounded to a method" at startup

I changed it in @plugin.init() and it works