### PR TITLE
Added skill for convert the value BTC into trading value (USD/EUR)

### DIFF
--- a/simpleFundsOverview/funds.py
+++ b/simpleFundsOverview/funds.py
@@ -186,7 +186,7 @@ def init(options, configuration, plugin):
     path = join(basedir, rpc_filename)
     plugin.log("rpc interface located at {}".format(path))
     rpc_interface = LightningRpc(path)
-    plugin.log("Funds Plugin successfully initialezed")
+    plugin.log("Funds Plugin successfully initialized")
     plugin.log("standard unit is set to {}".format(
         plugin.get_option("funds_display_unit")), level="debug")
 

--- a/simpleFundsOverview/requirements.txt
+++ b/simpleFundsOverview/requirements.txt
@@ -1,0 +1,2 @@
+pylightning>=0.0.7
+requests>=2.22.0


### PR DESCRIPTION
I utilized this https://developer.bitaps.com/market APi for getting information on actual trading value btc.

If the api response with the status code 200 the result is this 
```
{
   "total BTC": "0.10000000 BTC",
   "total EUR": "945.91000000 EUR",
   "onchain BTC": "0.10000000 BTC",
   "onchain EUR": "945.91000000 EUR",
   "offchainBTC": "0.00000000 BTC",
   "offchain EUR": "0.00000000 EUR",
   "informations": "The network is testnet, so the EUR not are real :("
}
```

if the status code is different the print is this

```
{
   "total BTC": "0.10000000 BTC",
   "onchain BTC": "0.10000000 BTC",
   "offchainBTC": "0.00000000 BTC",
}
```

So, the plugin work without the network.

The command now is `lightning-cli funds B eur`

I have inserted two maps for get correct value
```
unit_value = {
    "B": "BTC",
    "btc": "BTC",
    "bitcoin": "BTC",

    "m": "mBTC",
    "milli": "mBTC",

    "b": "bit",
    "bit": "bit",
    "bits": "bit",

    "s": "sat",
    "satoshi": "sat",
    "satoshis": "sat",
}

trading_value = {
    "EUR": "btceur",
    "eur": "btceur",

    "USD": "btcusd",
    "usd": "btcusd",
}
```

This pull request includes also this fix
- https://github.com/renepickhardt/c-lightning-plugin-collection/pull/4
- https://github.com/renepickhardt/c-lightning-plugin-collection/pull/3

Thanks for your work @renepickhardt  :)

My btc address fro support my work `3DcFNMPjYL39R5qMxHyPUcDpqQd8kBCBPv`